### PR TITLE
Fix email verification redirect and screenshot display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Production site URL for email verification links
+# Replace with your actual production domain
+VITE_SITE_URL=https://your-production-domain.com

--- a/EMAIL_VERIFICATION_FIX.md
+++ b/EMAIL_VERIFICATION_FIX.md
@@ -1,0 +1,37 @@
+# Email Verification Fix
+
+## Problem
+When users clicked email verification links, they were being redirected to `localhost:8080` instead of the production domain, causing connection errors.
+
+## Root Cause
+The `emailRedirectTo` URL in the Supabase auth signup was using `window.location.origin`, which resolves to `localhost:8080` during development but should use the production domain in production.
+
+## Solution
+1. **Environment Variable**: Added `VITE_SITE_URL` environment variable to specify the production domain
+2. **Configuration Utility**: Created `src/lib/config.ts` with utility functions to handle base URL logic
+3. **Updated AuthPage**: Modified the signup function to use the new configuration utility
+
+## Files Changed
+- `src/components/AuthPage.tsx` - Updated to use `getAuthRedirectUrl()` utility
+- `src/lib/config.ts` - New configuration utility file
+- `.env` - Environment variable for production URL
+- `.env.example` - Example environment file
+- `README.md` - Updated with setup instructions
+
+## Configuration
+1. Set the `VITE_SITE_URL` environment variable to your production domain:
+   ```env
+   VITE_SITE_URL=https://your-production-domain.com
+   ```
+
+2. The application will automatically use this URL for email verification links in production, while falling back to `window.location.origin` in development.
+
+## Testing
+- In development: Email verification links will point to `localhost:5173`
+- In production: Email verification links will point to your production domain
+
+## Benefits
+- ✅ Email verification links work correctly in production
+- ✅ No more localhost connection errors
+- ✅ Maintains development functionality
+- ✅ Centralized configuration for future auth flows

--- a/README.md
+++ b/README.md
@@ -40,12 +40,22 @@ A modern web application for running Apify actors with dynamic form generation a
    npm install
    ```
 
-3. Start the development server:
+3. Set up environment variables:
+   ```bash
+   cp .env.example .env
+   ```
+   
+   Edit `.env` and set your production domain:
+   ```env
+   VITE_SITE_URL=https://your-production-domain.com
+   ```
+
+4. Start the development server:
    ```bash
    npm run dev
    ```
 
-4. Open http://localhost:5173 in your browser
+5. Open http://localhost:5173 in your browser
 
 ### Production Build
 
@@ -101,6 +111,16 @@ All API calls are made securely with proper error handling and user feedback.
 - Guest mode API keys are stored locally and cleared on session end
 - All API requests use HTTPS
 - Input validation prevents malicious data injection
+
+## Email Verification
+
+The application uses Supabase Auth for email verification. To ensure email verification links work correctly in production:
+
+1. Set the `VITE_SITE_URL` environment variable to your production domain
+2. Configure your Supabase project's Site URL in the Supabase dashboard
+3. Email verification links will redirect users to your production domain instead of localhost
+
+**Important**: Without setting `VITE_SITE_URL`, email verification links will point to localhost and fail in production.
 
 ## Development
 

--- a/src/components/AuthPage.tsx
+++ b/src/components/AuthPage.tsx
@@ -13,6 +13,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { Navbar } from '@/components/Navbar';
 import { Footer } from '@/components/Footer';
+import { getAuthRedirectUrl } from '@/lib/config';
 
 interface AuthPageProps {
   onAuthSuccess: () => void;
@@ -77,7 +78,7 @@ export function AuthPage({ onAuthSuccess, onGuestAccess, defaultTab = 'signin', 
 
     setIsLoading(true);
     try {
-      const redirectUrl = `${window.location.origin}/`;
+      const redirectUrl = getAuthRedirectUrl('/');
       
       const { error } = await supabase.auth.signUp({
         email,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,25 @@
+/**
+ * Configuration utilities for the application
+ */
+
+/**
+ * Get the base URL for the application
+ * Uses environment variable VITE_SITE_URL in production, falls back to window.location.origin
+ */
+export function getBaseUrl(): string {
+  // In production, use the environment variable
+  if (import.meta.env.PROD && import.meta.env.VITE_SITE_URL) {
+    return import.meta.env.VITE_SITE_URL;
+  }
+  
+  // In development or if no environment variable is set, use window.location.origin
+  return window.location.origin;
+}
+
+/**
+ * Get the redirect URL for authentication flows (email verification, password reset, etc.)
+ */
+export function getAuthRedirectUrl(path: string = '/'): string {
+  const baseUrl = getBaseUrl();
+  return `${baseUrl}${path}`;
+}


### PR DESCRIPTION
Fix email verification links redirecting to localhost by using a configurable production URL.

The `emailRedirectTo` URL was using `window.location.origin`, which resolves to `localhost:8080` during development, causing verification links to fail in production. This PR introduces a `VITE_SITE_URL` environment variable and a utility function to ensure the correct production domain is used for authentication redirects.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba1335cc-e5fe-4f55-ad6d-29d010a635f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba1335cc-e5fe-4f55-ad6d-29d010a635f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>